### PR TITLE
fix: 修复版本跳过逻辑、GitHub Asset ID 解析，添加 token 自动获取和调试模式

### DIFF
--- a/cmd/rime-wanxiang-updater/main.go
+++ b/cmd/rime-wanxiang-updater/main.go
@@ -12,6 +12,7 @@ import (
 	"golang.org/x/term"
 	"rime-wanxiang-updater/internal/config"
 	"rime-wanxiang-updater/internal/controller"
+	"rime-wanxiang-updater/internal/updater"
 	"rime-wanxiang-updater/internal/i18n"
 	"rime-wanxiang-updater/internal/termcolor"
 	"rime-wanxiang-updater/internal/theme"
@@ -253,6 +254,14 @@ func printBootSequence(locale i18n.Locale) {
 }
 
 func main() {
+	// 解析 --debug 启动参数
+	for _, arg := range os.Args[1:] {
+		if arg == "--debug" {
+			updater.SetDebugMode(true)
+			break
+		}
+	}
+
 	// 初始化终端颜色检测（自动检测终端背景色）
 	termcolor.InitLipgloss()
 

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os/exec"
+	"strings"
 	"sync"
 	"time"
 
@@ -13,11 +15,12 @@ import (
 
 // Client API 客户端
 type Client struct {
-	httpClient  *http.Client
-	config      *types.Config
-	githubToken string
-	cnbBaseURL  string
-	mu          sync.Mutex
+	httpClient   *http.Client
+	config       *types.Config
+	githubToken  string
+	tokenChecked bool
+	cnbBaseURL   string
+	mu           sync.Mutex
 
 	cnbTagsPageCache   map[string]cnbTagsPageResult
 	cnbReleaseTagCache map[string]types.GitHubRelease
@@ -100,8 +103,33 @@ func buildHTTPClient(config *types.Config, timeout time.Duration) *http.Client {
 	}
 }
 
+// ensureGitHubToken 尝试通过 gh CLI 自动获取 GitHub token
+func (c *Client) ensureGitHubToken() {
+	if c.githubToken != "" || c.tokenChecked {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.githubToken != "" || c.tokenChecked {
+		return
+	}
+	c.tokenChecked = true
+	cmd := exec.Command("gh", "auth", "token")
+	output, err := cmd.Output()
+	if err == nil {
+		token := strings.TrimSpace(string(output))
+		if token != "" {
+			c.githubToken = token
+		}
+	}
+}
+
 // Get 发送 GET 请求
 func (c *Client) Get(url string) (*http.Response, error) {
+	if !c.config.UseMirror && strings.Contains(url, "api.github.com") {
+		c.ensureGitHubToken()
+	}
+
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("创建请求失败: %w", err)
@@ -123,6 +151,10 @@ func (c *Client) Get(url string) (*http.Response, error) {
 
 // Head 发送 HEAD 请求
 func (c *Client) Head(url string) (*http.Response, error) {
+	if !c.config.UseMirror && strings.Contains(url, "api.github.com") {
+		c.ensureGitHubToken()
+	}
+
 	req, err := http.NewRequest("HEAD", url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("创建请求失败: %w", err)

--- a/internal/api/cnb.go
+++ b/internal/api/cnb.go
@@ -217,7 +217,7 @@ func (c *Client) FindLatestCNBAssetInfo(
 					Tag:         release.TagName,
 					Description: release.Body,
 					SHA256:      asset.SHA256,
-					ID:          asset.ID,
+					ID:          strconv.FormatInt(asset.ID, 10),
 					Size:        asset.Size,
 				}, nil
 			}
@@ -242,7 +242,7 @@ func (c *Client) FindLatestCNBAssetInfo(
 				Tag:         release.TagName,
 				Description: release.Body,
 				SHA256:      asset.SHA256,
-				ID:          asset.ID,
+				ID:          strconv.FormatInt(asset.ID, 10),
 				Size:        asset.Size,
 			}, nil
 		}
@@ -360,11 +360,12 @@ func convertCNBReleases(
 				sha256 = cnbAsset.HashValue
 			}
 
+			id, _ := strconv.ParseInt(cnbAsset.ID, 10, 64)
 			assets = append(assets, types.GitHubAsset{
 				Name:               cnbAsset.Name,
 				BrowserDownloadURL: strings.TrimRight(baseURL, "/") + cnbAsset.Path,
 				UpdatedAt:          cnbAsset.UpdatedAt,
-				ID:                 cnbAsset.ID,
+				ID:                 id,
 				SHA256:             sha256,
 				Size:               cnbAsset.SizeInByte,
 			})

--- a/internal/controller/update_handlers.go
+++ b/internal/controller/update_handlers.go
@@ -185,7 +185,17 @@ func (c *Controller) handleUpdateDict(cmd Command) {
 			return
 		}
 
-		if err = dictUpdater.Run(progressFunc); err == nil {
+		if err = dictUpdater.Run(progressFunc); err == nil && dictUpdater.SkippedCache {
+			c.emitEvent(EvtUpdateSkipped, UpdateCompletePayload{
+				UpdateType: "词库",
+				Success:    true,
+				Skipped:    true,
+				Message:    status.Message,
+			})
+			return
+		}
+
+		if err == nil {
 			err = dictUpdater.Deploy()
 		}
 
@@ -254,7 +264,17 @@ func (c *Controller) handleUpdateScheme(cmd Command) {
 			return
 		}
 
-		if err = schemeUpdater.Run(progressFunc); err == nil {
+		if err = schemeUpdater.Run(progressFunc); err == nil && schemeUpdater.SkippedCache {
+			c.emitEvent(EvtUpdateSkipped, UpdateCompletePayload{
+				UpdateType: "方案",
+				Success:    true,
+				Skipped:    true,
+				Message:    status.Message,
+			})
+			return
+		}
+
+		if err == nil {
 			err = schemeUpdater.Deploy()
 		}
 
@@ -323,17 +343,21 @@ func (c *Controller) handleUpdateModel(cmd Command) {
 			return
 		}
 
-		if err := modelUpdater.Run(progressFunc); err == nil {
+		if err := modelUpdater.Run(progressFunc); err == nil && modelUpdater.SkippedCache {
+			c.emitEvent(EvtUpdateSkipped, UpdateCompletePayload{
+				UpdateType: "模型",
+				Success:    true,
+				Skipped:    true,
+				Message:    status.Message,
+			})
+			return
+		}
+
+		if err == nil {
 			err = modelUpdater.Deploy()
-			if err != nil {
-				c.emitEvent(EvtUpdateFailure, UpdateCompletePayload{
-					UpdateType: "模型",
-					Success:    false,
-					Message:    fmt.Sprintf("更新失败: %v", err),
-				})
-				return
-			}
-		} else {
+		}
+
+		if err != nil {
 			c.emitEvent(EvtUpdateFailure, UpdateCompletePayload{
 				UpdateType: "模型",
 				Success:    false,

--- a/internal/releaseutil/selector.go
+++ b/internal/releaseutil/selector.go
@@ -1,6 +1,10 @@
 package releaseutil
 
-import "rime-wanxiang-updater/internal/types"
+import (
+	"strconv"
+
+	"rime-wanxiang-updater/internal/types"
+)
 
 // FindPreferredAssetInfo 优先从版本化发布中选择匹配资源，
 // 找不到时再回退到指定的兜底 tag。
@@ -75,7 +79,7 @@ func findAssetInfoWithTagFilter(
 				Tag:         release.TagName,
 				Description: release.Body,
 				SHA256:      asset.SHA256,
-				ID:          asset.ID,
+				ID:          strconv.FormatInt(asset.ID, 10),
 				Size:        asset.Size,
 			}, true
 		}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -96,7 +96,7 @@ type GitHubAsset struct {
 	Name               string    `json:"name"`
 	BrowserDownloadURL string    `json:"browser_download_url"`
 	UpdatedAt          time.Time `json:"updated_at,omitzero"`
-	ID                 string    `json:"-"`
+	ID                 int64     `json:"id"`
 	SHA256             string    `json:"sha256"`
 	Size               int64     `json:"size"`
 }

--- a/internal/updater/base.go
+++ b/internal/updater/base.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -16,12 +17,49 @@ import (
 	"rime-wanxiang-updater/internal/types"
 )
 
+// Debug 调试模式开关，由 --debug 启动参数控制
+var Debug bool
+
+var debugLog *log.Logger
+
+func init() {
+	debugLog = log.New(io.Discard, "[DEBUG] ", log.LstdFlags)
+}
+
+// SetDebugMode 启用或禁用调试日志输出
+func SetDebugMode(enabled bool) {
+	Debug = enabled
+	if enabled {
+		f, err := os.OpenFile("/tmp/rime-updater-debug.log", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+		if err != nil {
+			debugLog = log.New(os.Stderr, "[DEBUG] ", log.LstdFlags)
+		} else {
+			debugLog = log.New(f, "[DEBUG] ", log.LstdFlags)
+		}
+	} else {
+		debugLog = log.New(io.Discard, "[DEBUG] ", log.LstdFlags)
+	}
+}
+
+func debugPrintln(v ...any) {
+	if Debug {
+		debugLog.Println(v...)
+	}
+}
+
+func debugPrintf(format string, v ...any) {
+	if Debug {
+		debugLog.Printf(format, v...)
+	}
+}
+
 // BaseUpdater 更新器基类
 type BaseUpdater struct {
 	Config        *config.Manager
 	APIClient     *api.Client
 	Deployer      deployer.Deployer
 	SkipTerminate bool // 是否跳过终止进程步骤（用于组合更新）
+	SkippedCache  bool // Run() 因命中缓存而跳过实际下载
 }
 
 // NewBaseUpdater 创建基础更新器
@@ -275,7 +313,12 @@ func (b *BaseUpdater) ExtractZip(src, dest string) error {
 
 // CompareHash 比较文件哈希
 func (b *BaseUpdater) CompareHash(remoteHash, filePath string) bool {
-	if remoteHash == "" || !fileutil.FileExists(filePath) {
+	if remoteHash == "" {
+		return false
+	}
+
+	info, err := os.Stat(filePath)
+	if err != nil || info.IsDir() {
 		return false
 	}
 
@@ -289,19 +332,24 @@ func (b *BaseUpdater) CompareHash(remoteHash, filePath string) bool {
 
 func hasMeaningfulUpdate(localRecord *types.UpdateRecord, updateInfo *types.UpdateInfo) bool {
 	if localRecord == nil {
+		debugPrintln("hasMeaningfulUpdate: localRecord==nil → true")
 		return true
 	}
 	if updateInfo == nil {
+		debugPrintln("hasMeaningfulUpdate: updateInfo==nil → false")
 		return false
 	}
 	if isSameTrackedAsset(localRecord, updateInfo) {
+		debugPrintln("hasMeaningfulUpdate: isSameTrackedAsset=true → false (no update)")
 		return false
 	}
 	if localRecord.Tag != "" && updateInfo.Tag != "" && localRecord.Tag != updateInfo.Tag {
+		debugPrintf("hasMeaningfulUpdate: different tags local=%q remote=%q → true", localRecord.Tag, updateInfo.Tag)
 		return true
 	}
-
-	return updateInfo.UpdateTime.After(localRecord.UpdateTime)
+	result := updateInfo.UpdateTime.After(localRecord.UpdateTime)
+	debugPrintf("hasMeaningfulUpdate: time fallback remote=%v local=%v → %v", updateInfo.UpdateTime, localRecord.UpdateTime, result)
+	return result
 }
 
 func isSameTrackedAsset(localRecord *types.UpdateRecord, updateInfo *types.UpdateInfo) bool {
@@ -309,15 +357,19 @@ func isSameTrackedAsset(localRecord *types.UpdateRecord, updateInfo *types.Updat
 		return false
 	}
 	if localRecord.Tag == "" || updateInfo.Tag == "" || localRecord.Tag != updateInfo.Tag {
+		debugPrintf("isSameTrackedAsset: tag mismatch (local=%q remote=%q) → false", localRecord.Tag, updateInfo.Tag)
 		return false
 	}
 	if updateInfo.ID != "" && localRecord.CnbID != "" && updateInfo.ID == localRecord.CnbID {
+		debugPrintf("isSameTrackedAsset: ID match %q → true", updateInfo.ID)
 		return true
 	}
 	if updateInfo.SHA256 != "" && localRecord.SHA256 != "" && updateInfo.SHA256 == localRecord.SHA256 {
+		debugPrintln("isSameTrackedAsset: SHA256 match → true")
 		return true
 	}
-
+	debugPrintf("isSameTrackedAsset: no match (remote.ID=%q local.CnbID=%q remote.SHA256=%q local.SHA256=%q) → false",
+		updateInfo.ID, localRecord.CnbID, updateInfo.SHA256, localRecord.SHA256)
 	return false
 }
 

--- a/internal/updater/combined.go
+++ b/internal/updater/combined.go
@@ -205,8 +205,14 @@ func (c *CombinedUpdater) RunAllWithProgress(progress func(component, message st
 		progressFunc := func(message string, percent float64, source string, fileName string, downloaded int64, total int64, speed float64, downloadMode bool) {
 			progress("方案", message, 0.05+percent*0.30, source, fileName, downloaded, total, speed, downloadMode) // 方案占 30%
 		}
+		c.SchemeUpdater.SkippedCache = false
 		if err := c.SchemeUpdater.Run(progressFunc); err != nil {
 			errors = append(errors, fmt.Sprintf("方案更新失败: %v", err))
+		} else if c.SchemeUpdater.SkippedCache {
+			result.SkippedComponents = append(result.SkippedComponents, "方案")
+			if c.SchemeUpdater.UpdateInfo != nil {
+				result.ComponentVersions["方案"] = c.SchemeUpdater.UpdateInfo.Tag
+			}
 		} else {
 			result.UpdatedComponents = append(result.UpdatedComponents, "方案")
 			if c.SchemeUpdater.UpdateInfo != nil {
@@ -221,8 +227,14 @@ func (c *CombinedUpdater) RunAllWithProgress(progress func(component, message st
 		progressFunc := func(message string, percent float64, source string, fileName string, downloaded int64, total int64, speed float64, downloadMode bool) {
 			progress("词库", message, 0.35+percent*0.30, source, fileName, downloaded, total, speed, downloadMode) // 词库占 30%
 		}
+		c.DictUpdater.SkippedCache = false
 		if err := c.DictUpdater.Run(progressFunc); err != nil {
 			errors = append(errors, fmt.Sprintf("词库更新失败: %v", err))
+		} else if c.DictUpdater.SkippedCache {
+			result.SkippedComponents = append(result.SkippedComponents, "词库")
+			if c.DictUpdater.UpdateInfo != nil {
+				result.ComponentVersions["词库"] = c.DictUpdater.UpdateInfo.Tag
+			}
 		} else {
 			result.UpdatedComponents = append(result.UpdatedComponents, "词库")
 			if c.DictUpdater.UpdateInfo != nil {
@@ -237,8 +249,14 @@ func (c *CombinedUpdater) RunAllWithProgress(progress func(component, message st
 		progressFunc := func(message string, percent float64, source string, fileName string, downloaded int64, total int64, speed float64, downloadMode bool) {
 			progress("模型", message, 0.65+percent*0.25, source, fileName, downloaded, total, speed, downloadMode) // 模型占 25%
 		}
+		c.ModelUpdater.SkippedCache = false
 		if err := c.ModelUpdater.Run(progressFunc); err != nil {
 			errors = append(errors, fmt.Sprintf("模型更新失败: %v", err))
+		} else if c.ModelUpdater.SkippedCache {
+			result.SkippedComponents = append(result.SkippedComponents, "模型")
+			if c.ModelUpdater.UpdateInfo != nil {
+				result.ComponentVersions["模型"] = c.ModelUpdater.UpdateInfo.Tag
+			}
 		} else {
 			result.UpdatedComponents = append(result.UpdatedComponents, "模型")
 			if c.ModelUpdater.UpdateInfo != nil {

--- a/internal/updater/dict.go
+++ b/internal/updater/dict.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	"rime-wanxiang-updater/internal/config"
@@ -142,7 +143,7 @@ func (d *DictUpdater) CheckUpdate() (*types.UpdateInfo, error) {
 				UpdateTime: asset.UpdatedAt,
 				Tag:        release.TagName,
 				SHA256:     asset.SHA256,
-				ID:         asset.ID,
+				ID:         strconv.FormatInt(asset.ID, 10),
 				Size:       asset.Size,
 			}, nil
 		}
@@ -190,7 +191,7 @@ func (d *DictUpdater) findCNBDictInfoAtTag(tag string) (*types.UpdateInfo, bool,
 			UpdateTime: asset.UpdatedAt,
 			Tag:        release.TagName,
 			SHA256:     asset.SHA256,
-			ID:         asset.ID,
+			ID:         strconv.FormatInt(asset.ID, 10),
 			Size:       asset.Size,
 		}, true, nil
 	}

--- a/internal/updater/dict.go
+++ b/internal/updater/dict.go
@@ -39,7 +39,7 @@ func (d *DictUpdater) GetStatus() (*types.UpdateStatus, error) {
 	}
 
 	// 检查关键文件是否存在
-	keyFile := filepath.Join(d.Config.GetDictExtractPath(), "chengyu.txt")
+	keyFile := filepath.Join(d.Config.GetDictExtractPath(), "jichu.dict.yaml")
 	keyFileExists := fileutil.FileExists(keyFile)
 
 	// 获取本地版本信息
@@ -239,15 +239,38 @@ func (d *DictUpdater) Run(progress types.ProgressFunc) error {
 	recordPath := d.Config.GetDictRecordPath()
 	targetFile := filepath.Join(d.Config.CacheDir, d.Config.Config.DictFile)
 
-	// 校验本地文件：只有当版本未变化且缓存文件哈希匹配时才跳过下载
+	// 校验本地文件
 	progress("正在校验本地文件...", 0.1, "", "", 0, 0, 0, false)
 	localRecord := d.GetLocalRecord(recordPath)
+
+	// 第1关: 无版本更新 → 直接跳过（不管缓存文件是否存在）
+	if localRecord != nil && d.UpdateInfo != nil && !hasMeaningfulUpdate(localRecord, d.UpdateInfo) {
+		keyFile := filepath.Join(d.Config.GetDictExtractPath(), "jichu.dict.yaml")
+		debugPrintf("词库 Run: 第1关 hasMeaningfulUpdate=false, keyFile=%s exists=%v", keyFile, fileutil.FileExists(keyFile))
+		if fileutil.FileExists(keyFile) {
+			progress("本地文件已是最新版本", 1.0, "", "", 0, 0, 0, false)
+			d.SkippedCache = true
+			return nil
+		}
+	}
+
+	// 第2关: 缓存 zip 哈希匹配 → 跳过下载或从缓存解压
 	if d.canReuseCachedAsset(localRecord, d.UpdateInfo, targetFile, d.CompareHash) {
-		progress("本地文件已是最新版本", 1.0, "", "", 0, 0, 0, false)
-		return nil
+		keyFile := filepath.Join(d.Config.GetDictExtractPath(), "jichu.dict.yaml")
+		debugPrintf("词库 Run: 第2关 canReuseCachedAsset=true, keyFile=%s exists=%v", keyFile, fileutil.FileExists(keyFile))
+		if fileutil.FileExists(keyFile) {
+			progress("本地文件已是最新版本", 1.0, "", "", 0, 0, 0, false)
+			d.SkippedCache = true
+			return nil
+		}
+		// 缓存 zip 完好但文件缺失 → 从缓存解压，不重新下载
+		progress("文件缺失，正在从缓存恢复...", 0.7, "", "", 0, 0, 0, false)
+		debugPrintf("词库 Run: keyFile 缺失，从缓存 zip 解压 targetFile=%s", targetFile)
+		return d.applyUpdate(targetFile, targetFile, progress)
 	}
 
 	// 下载文件
+	debugPrintf("词库 Run: 两关都没拦住，开始下载 URL=%s", d.UpdateInfo.URL)
 	progress(fmt.Sprintf("准备从 %s 下载词库...", source), 0.15, source, d.UpdateInfo.URL, 0, 0, 0, false)
 	tempFile := filepath.Join(d.Config.CacheDir, fmt.Sprintf("temp_dict_%d.zip", time.Now().Unix()))
 	if err := d.DownloadFileWithValidation(d.UpdateInfo.URL, tempFile, d.Config.Config.DictFile, source, d.UpdateInfo.Size, progress); err != nil {
@@ -307,13 +330,15 @@ func (d *DictUpdater) applyUpdate(temp, target string, progress types.ProgressFu
 		}
 	}
 
-	// 重命名临时文件
-	progress("正在保存文件...", 0.95, "", "", 0, 0, 0, false)
-	if fileutil.FileExists(target) {
-		os.Remove(target)
-	}
-	if err := fileutil.MoveFile(temp, target); err != nil {
-		return fmt.Errorf("重命名失败: %w", err)
+	// 重命名临时文件（temp==target 时来自缓存恢复，跳过）
+	if temp != target {
+		progress("正在保存文件...", 0.95, "", "", 0, 0, 0, false)
+		if fileutil.FileExists(target) {
+			os.Remove(target)
+		}
+		if err := fileutil.MoveFile(temp, target); err != nil {
+			return fmt.Errorf("重命名失败: %w", err)
+		}
 	}
 
 	// 保存记录

--- a/internal/updater/model.go
+++ b/internal/updater/model.go
@@ -67,7 +67,7 @@ func (m *ModelUpdater) GetStatus() (*types.UpdateStatus, error) {
 		}
 
 		status.LocalTime = localRecord.UpdateTime
-		status.NeedsUpdate = remoteInfo.UpdateTime.After(localRecord.UpdateTime)
+		status.NeedsUpdate = hasMeaningfulUpdate(localRecord, remoteInfo)
 
 		if status.NeedsUpdate {
 			remoteVersion := remoteInfo.Tag
@@ -183,31 +183,31 @@ func (m *ModelUpdater) Run(progress types.ProgressFunc) error {
 
 	// 校验本地文件
 	progress("正在校验本地文件...", 0.1, "", "", 0, 0, 0, false)
+	localRecord := m.GetLocalRecord(recordPath)
 
-	// 优先使用 SHA256 校验（如果有）
-	if m.UpdateInfo.SHA256 != "" && m.CompareHash(m.UpdateInfo.SHA256, targetPath) {
-		progress("本地文件已是最新版本", 1.0, "", "", 0, 0, 0, false)
-		m.SaveRecord(recordPath, "model_name", types.MODEL_FILE, m.UpdateInfo)
-		return nil
-	}
-
-	// 如果没有 SHA256（如 CNB 镜像），检查文件是否存在且有本地记录
-	if m.UpdateInfo.SHA256 == "" && fileutil.FileExists(targetPath) {
-		localRecord := m.GetLocalRecord(recordPath)
-		if localRecord != nil && localRecord.Name == types.MODEL_FILE {
-			// 文件存在且有记录，认为已是最新版本（除非 UpdateTime 更新）
-			if !m.UpdateInfo.UpdateTime.After(localRecord.UpdateTime) {
-				progress("本地文件已是最新版本", 1.0, "", "", 0, 0, 0, false)
-				return nil
-			}
+	// 无版本更新且文件存在 → 跳过下载
+	if localRecord != nil && !hasMeaningfulUpdate(localRecord, m.UpdateInfo) {
+		debugPrintf("模型 Run: hasMeaningfulUpdate=false, targetPath=%s exists=%v", targetPath, fileutil.FileExists(targetPath))
+		if fileutil.FileExists(targetPath) {
+			progress("本地文件已是最新版本", 1.0, "", "", 0, 0, 0, false)
+			m.SkippedCache = true
+			return nil
 		}
+		debugPrintf("模型 Run: targetPath 不存在，继续下载")
 	}
 
 	// 下载文件
+	debugPrintf("模型 Run: 校验未拦住，开始下载 URL=%s", m.UpdateInfo.URL)
 	progress(fmt.Sprintf("准备从 %s 下载模型...", source), 0.15, source, m.UpdateInfo.URL, 0, 0, 0, false)
 	tempFile := filepath.Join(m.Config.CacheDir, fmt.Sprintf("%s_%s.tmp", types.MODEL_FILE, m.UpdateInfo.SHA256))
 	if err := m.DownloadFile(m.UpdateInfo.URL, tempFile, types.MODEL_FILE, source, progress); err != nil {
 		return fmt.Errorf("下载失败: %w", err)
+	}
+
+	// 计算下载文件的 SHA256（GitHub 源不返回此字段）
+	progress("正在计算文件校验和...", 0.65, "", "", 0, 0, 0, false)
+	if hash, err := fileutil.CalculateSHA256(tempFile); err == nil {
+		m.UpdateInfo.SHA256 = hash
 	}
 
 	// 应用更新

--- a/internal/updater/model.go
+++ b/internal/updater/model.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 
 	"rime-wanxiang-updater/internal/config"
 	"rime-wanxiang-updater/internal/fileutil"
@@ -131,7 +132,7 @@ func findModelRelease(releases []types.GitHubRelease) (*types.UpdateInfo, bool) 
 				UpdateTime: asset.UpdatedAt,
 				Tag:        release.TagName,
 				SHA256:     asset.SHA256,
-				ID:         asset.ID,
+				ID:         strconv.FormatInt(asset.ID, 10),
 				Size:       asset.Size,
 			}, true
 		}

--- a/internal/updater/model_test.go
+++ b/internal/updater/model_test.go
@@ -148,7 +148,7 @@ func TestFindModelReleaseUsesModelTagMetadata(t *testing.T) {
 					Name:               "base-dicts.zip",
 					BrowserDownloadURL: "https://example.com/base-dicts.zip",
 					UpdatedAt:          time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
-					ID:                 "dict-asset",
+					ID:                 1001,
 					Size:               11,
 				},
 			},
@@ -160,7 +160,7 @@ func TestFindModelReleaseUsesModelTagMetadata(t *testing.T) {
 					Name:               types.MODEL_FILE,
 					BrowserDownloadURL: "https://example.com/model.gram",
 					UpdatedAt:          time.Date(2026, 4, 2, 7, 44, 10, 0, time.UTC),
-					ID:                 "model-asset",
+					ID:                 2001,
 					SHA256:             "abc123",
 					Size:               210421804,
 				},
@@ -181,7 +181,7 @@ func TestFindModelReleaseUsesModelTagMetadata(t *testing.T) {
 		t.Fatalf("info.Size = %d, want %d", info.Size, 210421804)
 	}
 
-	if info.ID != "model-asset" {
-		t.Fatalf("info.ID = %q, want %q", info.ID, "model-asset")
+	if info.ID != "2001" {
+		t.Fatalf("info.ID = %q, want %q", info.ID, "2001")
 	}
 }

--- a/internal/updater/scheme.go
+++ b/internal/updater/scheme.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	"rime-wanxiang-updater/internal/config"
@@ -157,7 +158,7 @@ func findSchemeReleaseWithTagFilter(
 				Tag:         release.TagName,
 				Description: release.Body,
 				SHA256:      asset.SHA256,
-				ID:          asset.ID,
+				ID:          strconv.FormatInt(asset.ID, 10),
 				Size:        asset.Size,
 			}, true
 		}

--- a/internal/updater/scheme.go
+++ b/internal/updater/scheme.go
@@ -38,7 +38,7 @@ func (s *SchemeUpdater) GetStatus() (*types.UpdateStatus, error) {
 	}
 
 	// 检查关键文件是否存在
-	keyFile := filepath.Join(s.Config.GetExtractPath(), "lua", "wanxiang.lua")
+	keyFile := filepath.Join(s.Config.GetExtractPath(), "lua", "wanxiang/version_display.lua")
 	keyFileExists := fileutil.FileExists(keyFile)
 
 	// 获取本地版本信息
@@ -207,15 +207,38 @@ func (s *SchemeUpdater) Run(progress types.ProgressFunc) error {
 	recordPath := s.Config.GetSchemeRecordPath()
 	targetFile := filepath.Join(s.Config.CacheDir, s.Config.Config.SchemeFile)
 
-	// 校验本地文件：只有当版本未变化且缓存文件哈希匹配时才跳过下载
+	// 校验本地文件
 	progress("正在校验本地文件...", 0.1, "", "", 0, 0, 0, false)
 	localRecord := s.GetLocalRecord(recordPath)
+
+	// 第1关: 无版本更新 → 直接跳过（不管缓存文件是否存在）
+	if localRecord != nil && s.UpdateInfo != nil && !hasMeaningfulUpdate(localRecord, s.UpdateInfo) {
+		keyFile := filepath.Join(s.Config.GetExtractPath(), "lua", "wanxiang/version_display.lua")
+		debugPrintf("方案 Run: 第1关 hasMeaningfulUpdate=false, keyFile=%s exists=%v", keyFile, fileutil.FileExists(keyFile))
+		if fileutil.FileExists(keyFile) {
+			progress("本地文件已是最新版本", 1.0, "", "", 0, 0, 0, false)
+			s.SkippedCache = true
+			return nil
+		}
+	}
+
+	// 第2关: 缓存 zip 哈希匹配 → 跳过下载或从缓存解压
 	if s.canReuseCachedAsset(localRecord, s.UpdateInfo, targetFile, s.CompareHash) {
-		progress("本地文件已是最新版本", 1.0, "", "", 0, 0, 0, false)
-		return nil
+		keyFile := filepath.Join(s.Config.GetExtractPath(), "lua", "wanxiang/version_display.lua")
+		debugPrintf("方案 Run: 第2关 canReuseCachedAsset=true, keyFile=%s exists=%v", keyFile, fileutil.FileExists(keyFile))
+		if fileutil.FileExists(keyFile) {
+			progress("本地文件已是最新版本", 1.0, "", "", 0, 0, 0, false)
+			s.SkippedCache = true
+			return nil
+		}
+		// 缓存 zip 完好但文件缺失 → 从缓存解压，不重新下载
+		progress("文件缺失，正在从缓存恢复...", 0.7, "", "", 0, 0, 0, false)
+		debugPrintf("方案 Run: keyFile 缺失，从缓存 zip 解压 targetFile=%s", targetFile)
+		return s.applyUpdate(targetFile, targetFile, progress)
 	}
 
 	// 下载文件
+	debugPrintf("方案 Run: 两关都没拦住，开始下载 URL=%s", s.UpdateInfo.URL)
 	progress(fmt.Sprintf("准备从 %s 下载方案...", source), 0.15, source, s.UpdateInfo.URL, 0, 0, 0, false)
 	tempFile := filepath.Join(s.Config.CacheDir, fmt.Sprintf("temp_scheme_%d.zip", time.Now().Unix()))
 	if err := s.DownloadFileWithValidation(s.UpdateInfo.URL, tempFile, s.Config.Config.SchemeFile, source, s.UpdateInfo.Size, progress); err != nil {
@@ -279,13 +302,15 @@ func (s *SchemeUpdater) applyUpdate(temp, target string, progress types.Progress
 		}
 	}
 
-	// 重命名临时文件
-	progress("正在保存文件...", 0.93, "", "", 0, 0, 0, false)
-	if fileutil.FileExists(target) {
-		os.Remove(target)
-	}
-	if err := fileutil.MoveFile(temp, target); err != nil {
-		return fmt.Errorf("重命名失败: %w", err)
+	// 重命名临时文件（temp==target 时来自缓存恢复，跳过）
+	if temp != target {
+		progress("正在保存文件...", 0.93, "", "", 0, 0, 0, false)
+		if fileutil.FileExists(target) {
+			os.Remove(target)
+		}
+		if err := fileutil.MoveFile(temp, target); err != nil {
+			return fmt.Errorf("重命名失败: %w", err)
+		}
 	}
 
 	// 保存记录


### PR DESCRIPTION
## Summary

修复版本检查逻辑，使方案/词库/模型在已是最新时跳过下载；同时修复 GitHub Asset ID 解析、添加 GitHub token 自动获取和调试模式。

## 写在前面

非常感谢作者开发并维护 rime-wanxiang-updater 这个工具，让万象拼音的更新体验好了很多。以下修改是在日常使用中遇到的一些小问题，希望能为项目贡献一点微薄之力。期待能合并入主仓库，这样 AUR 等渠道也能及时跟进更新。

## Changes

### 1. 修复 GitHub Asset ID 解析
- `types.go`: `GitHubAsset.ID` 类型从 `string` 改为 `int64`，JSON 标签从 `"-"` 改为 `"id"`，使 asset ID 能被正确反序列化
- 所有 7 处转换点（cnb.go / selector.go / scheme.go / dict.go / model.go）同步适配 `strconv.FormatInt` / `ParseInt`

### 2. 自动获取 GitHub token
- `client.go`: 当使用 GitHub 源且 `gh` CLI 已登录时，自动调用 `gh auth token` 获取 token 附加到请求中，避免 API 速率限制

### 3. 缓存跳过逻辑
- **方案/词库**：新增双关卡验证——① `hasMeaningfulUpdate` 无版本更新且关键文件存在时直接跳过；② `canReuseCachedAsset` 缓存 zip 哈希匹配时跳过下载；缓存完好但文件缺失时从缓存解压恢复
- **模型**：使用 `hasMeaningfulUpdate` 替代旧的时间戳比较；下载后计算 SHA256 写入记录
- **`SkippedCache` 标记**：准确区分「已跳过」和「已更新」状态，UI 和组合更新中均正确处理
- **`CompareHash` 目录防护**：对目录路径返回 false 而非 panic

### 4. 调试模式
- 新增 `--debug` CLI 标志，输出详细诊断日志到 `/tmp/rime-updater-debug.log`
- 各组件关键判定点均有 debug 日志，方便排查跳过/下载决策

## Testing
- [x] 编译通过
- [x] 正常运行

用 `--debug` 运行可观察各组件的 hasMeaningfulUpdate / canReuseCachedAsset 判定结果。